### PR TITLE
gcc fixes for dpow

### DIFF
--- a/src/komodo_validation012.h
+++ b/src/komodo_validation012.h
@@ -58,6 +58,7 @@
 #include <base58.h>
 #include "komodo_notaries.h"
 #include "validation.h"
+#include "init.h"
 
 #define SATOSHIDEN ((uint64_t)100000000L)
 #define dstr(x) ((double)(x) / SATOSHIDEN)
@@ -84,7 +85,7 @@ typedef union _bits256 bits256;
 struct sha256_vstate { uint64_t length; uint32_t state[8],curlen; uint8_t buf[64]; };
 struct rmd160_vstate { uint64_t length; uint8_t buf[64]; uint32_t curlen, state[5]; };
 int32_t KOMODO_TXINDEX = 1;
-void ImportAddress(CWallet* const pwallet, const CBitcoinAddress& address, const std::string& strLabel);
+void ImportAddress(const CBitcoinAddress& address, const std::string& strLabel);
 
 int32_t gettxout_scriptPubKey(int32_t height,uint8_t *scriptPubKey,int32_t maxsize,uint256 txid,int32_t n)
 {
@@ -143,7 +144,7 @@ int32_t komodo_importaddress(std::string addr)
             else
             {
                 //printf("komodo_importaddress %s\n",addr.c_str());
-                ImportAddress(pwallet, address, addr);
+                ImportAddress(address, addr);
                 return(1);
             }
         }

--- a/src/komodo_validation012.h
+++ b/src/komodo_validation012.h
@@ -53,7 +53,6 @@
     obj.pushKV("notarized_MoM",         NOTARIZED_MOM.GetHex());
 }*/
 
-#include "init.h"
 #include <wallet/wallet.h>
 #include <chainparams.h>
 #include <base58.h>
@@ -85,7 +84,7 @@ typedef union _bits256 bits256;
 struct sha256_vstate { uint64_t length; uint32_t state[8],curlen; uint8_t buf[64]; };
 struct rmd160_vstate { uint64_t length; uint8_t buf[64]; uint32_t curlen, state[5]; };
 int32_t KOMODO_TXINDEX = 1;
-void ImportAddress(const CBitcoinAddress& address, const std::string& strLabel);
+void ImportAddress(CWallet* const pwallet, const CBitcoinAddress& address, const std::string& strLabel);
 
 int32_t gettxout_scriptPubKey(int32_t height,uint8_t *scriptPubKey,int32_t maxsize,uint256 txid,int32_t n)
 {
@@ -144,7 +143,7 @@ int32_t komodo_importaddress(std::string addr)
             else
             {
                 //printf("komodo_importaddress %s\n",addr.c_str());
-                ImportAddress(address, addr);
+                ImportAddress(pwallet, address, addr);
                 return(1);
             }
         }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -30,7 +30,6 @@
 #include <boost/algorithm/string.hpp>
 
 #include <univalue.h>
-#include "komodo_validation012.h"
 
 using namespace std;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -50,7 +50,6 @@
 #include <boost/math/distributions/poisson.hpp>
 #include <boost/thread.hpp>
 #include "komodo_validation012.h"
-#include "wallet/wallet.h"
 
 using namespace std;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -49,9 +49,11 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/math/distributions/poisson.hpp>
 #include <boost/thread.hpp>
-#include "komodo_validation012.h"
 
 using namespace std;
+void komodo_disconnect(CBlockIndex *pindex,CBlock *block);
+int32_t komodo_checkpoint(int32_t *notarized_heightp,int32_t nHeight,uint256 hash);
+void komodo_connectblock(CBlockIndex *pindex,CBlock& block);
 
 #if defined(NDEBUG)
 # error "Gincoin Core cannot be compiled without assertions."

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -152,6 +152,33 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     return NullUniValue;
 }
 
+void ImportAddress(const CBitcoinAddress& address, const string& strLabel);
+void ImportScript(const CScript& script, const string& strLabel, bool isRedeemScript)
+{
+    if (!isRedeemScript && ::IsMine(*pwalletMain, script) == ISMINE_SPENDABLE)
+        throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
+
+    pwalletMain->MarkDirty();
+
+    if (!pwalletMain->HaveWatchOnly(script) && !pwalletMain->AddWatchOnly(script))
+        throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
+
+    if (isRedeemScript) {
+        if (!pwalletMain->HaveCScript(script) && !pwalletMain->AddCScript(script))
+            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
+        ImportAddress(CBitcoinAddress(CScriptID(script)), strLabel);
+    }
+}
+
+void ImportAddress(const CBitcoinAddress& address, const string& strLabel)
+{
+    CScript script = GetScriptForDestination(address.Get());
+    ImportScript(script, strLabel, false);
+    // add to address book or update label
+    if (address.IsValid())
+        pwalletMain->SetAddressBook(address.Get(), strLabel, "receive");
+}
+
 UniValue importaddress(const UniValue& params, bool fHelp)
 {
     if (!EnsureWalletIsAvailable(fHelp))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -19,6 +19,7 @@
 #include "wallet/crypter.h"
 #include "wallet/wallet_ismine.h"
 #include "wallet/walletdb.h"
+#include "rpc/protocol.h"
 
 #include "privatesend.h"
 
@@ -41,6 +42,7 @@ extern CAmount maxTxFee;
 extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fSendFreeTransactions;
+extern CWallet* pwalletMain;
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -19,7 +19,6 @@
 #include "wallet/crypter.h"
 #include "wallet/wallet_ismine.h"
 #include "wallet/walletdb.h"
-#include "rpc/protocol.h"
 
 #include "privatesend.h"
 
@@ -42,7 +41,6 @@ extern CAmount maxTxFee;
 extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fSendFreeTransactions;
-extern CWallet* pwalletMain;
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default
@@ -1095,34 +1093,5 @@ public:
         READWRITE(vchPubKey);
     }
 };
-
-using namespace std;
-
-void ImportAddress(const CBitcoinAddress& address, const string& strLabel);
-void ImportScript(const CScript& script, const string& strLabel, bool isRedeemScript)
-{
-    if (!isRedeemScript && ::IsMine(*pwalletMain, script) == ISMINE_SPENDABLE)
-        throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
-
-    pwalletMain->MarkDirty();
-
-    if (!pwalletMain->HaveWatchOnly(script) && !pwalletMain->AddWatchOnly(script))
-        throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
-
-    if (isRedeemScript) {
-        if (!pwalletMain->HaveCScript(script) && !pwalletMain->AddCScript(script))
-            throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
-        ImportAddress(CBitcoinAddress(CScriptID(script)), strLabel);
-    }
-}
-
-void ImportAddress(const CBitcoinAddress& address, const string& strLabel)
-{
-    CScript script = GetScriptForDestination(address.Get());
-    ImportScript(script, strLabel, false);
-    // add to address book or update label
-    if (address.IsValid())
-        pwalletMain->SetAddressBook(address.Get(), strLabel, "receive");
-}
 
 #endif // BITCOIN_WALLET_WALLET_H


### PR DESCRIPTION
gcc version 5.4.0 seems to like this code, and also clang does not complain.

The core problem was including komodo_validation012.h multiple times, which is not a good idea, and just happened to work in clang.