### PR TITLE
Fix St13runtime_error

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3248,7 +3248,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
         {
             fprintf(stderr,"got a pre notarization block that matches height.%d\n",(int32_t)nHeight);
             return true;
-        } else return state.DoS(100, error("%s: forked chain %d older than last notarized (height %d) vs %d", __func__,nHeight, notarized_height));
+        } else return state.DoS(100, error("%s: forked chain %d older than last notarized (height %d)", __func__,nHeight, notarized_height));
     }
 
     return true;


### PR DESCRIPTION
This removes an extra conversion specifier that caused error spam in the console.