### PR TITLE
Ignore non-updated nodes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,10 +125,10 @@ public:
         consensus.nX16rtTimestamp = 1550246400; //Feb 15, 2019 @ 4pm GMT
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000331293c5e9f8112e");
+        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000432bb6a78bdfd088");
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x0000000000015fe3dbdb0ed7d40bd4441bc1c775441ad14052770d9e8306e3a6");
+        consensus.defaultAssumeValid = uint256S("0x00000000000c387c392dcced588abbd71b786f71dca736aa0566ce312f62f8c1"); // 260,000
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -192,11 +192,12 @@ public:
                     ( 1000, uint256S("0x00000000015079cff402ec1f9d88af43eba786f1a70bed49eca4c96b1786c074"))
                     ( 22092, uint256S("0x00000000000a106c24554e369cdacdb683fd6daef276ca38b1991ad82e74dc63"))
                     ( 225000, uint256S("0x0000000000015fe3dbdb0ed7d40bd4441bc1c775441ad14052770d9e8306e3a6"))
+                    ( 260000, uint256S("0x00000000000c387c392dcced588abbd71b786f71dca736aa0566ce312f62f8c1"))
             ,
-            1548176715, // * UNIX timestamp of last checkpoint block
-            470784,     // * total number of transactions between genesis and last checkpoint
+            1552502805, // * UNIX timestamp of last checkpoint block
+            542874,     // * total number of transactions between genesis and last checkpoint
                         //   (the tx=... number in the SetBestChain debug.log lines)
-            5000        // * estimated number of transactions per day after checkpoint
+            1350        // * estimated number of transactions per day after checkpoint
         };
     }
 };


### PR DESCRIPTION
The presence of non-updated nodes on the network sometimes interferes with sync. Updates chainparams to avoid this.